### PR TITLE
PHP7.4 deprecates first implode parameter being pieces, second glue

### DIFF
--- a/lib/swiftmailer_generate_mimes_config.php
+++ b/lib/swiftmailer_generate_mimes_config.php
@@ -173,7 +173,7 @@ function generateUpToDateMimeArray()
     ksort($valid_mime_types);
 
     // combine mime types and extensions array
-    $output = "$preamble\$swift_mime_types = array(\n    ".implode($valid_mime_types, ",\n    ")."\n);";
+    $output = "$preamble\$swift_mime_types = array(\n    ".implode(",\n    ", $valid_mime_types)."\n);";
 
     // write mime_types.php config file
     @file_put_contents('./mime_types.php', $output);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 
| License       | MIT


PHP 7.4 deprecates in the implode function the use of the 'pieces' parameter as the first parameter and the 'glue' parameter as the second parameter.
